### PR TITLE
Add GSAP animation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,21 @@ npm run build
 ```sh
 npm test
 ```
+
+## Animations
+
+This project uses [GSAP](https://greensock.com/gsap/) for animations. The library is installed as a Vue plugin in `src/plugins/gsap.ts` and registered in `src/main.ts`. You can access the instance in components via `this.$gsap`.
+
+Example:
+
+```vue
+<script setup lang="ts">
+import { onMounted, getCurrentInstance } from 'vue'
+
+const { $gsap } = getCurrentInstance()!.appContext.config.globalProperties
+
+onMounted(() => {
+  $gsap.from('.container', { opacity: 0, y: 20 })
+})
+</script>
+```

--- a/env.d.ts
+++ b/env.d.ts
@@ -1,1 +1,7 @@
 /// <reference types="vite/client" />
+
+declare module 'vue' {
+  interface ComponentCustomProperties {
+    $gsap: typeof import('gsap').gsap
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "portfolio",
       "version": "0.0.0",
       "dependencies": {
+        "gsap": "^3.13.0",
         "vue": "^3.5.13",
         "vue-router": "^4.5.0"
       },
@@ -2723,6 +2724,12 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/gsap": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.13.0.tgz",
+      "integrity": "sha512-QL7MJ2WMjm1PHWsoFrAQH/J8wUeqZvMtHO58qdekHpCfhvhSL4gSiz6vJf5EeMP0LOn3ZCprL2ki/gjED8ghVw==",
+      "license": "Standard 'no charge' license: https://gsap.com/standard-license."
     },
     "node_modules/he": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "vitest"
   },
   "dependencies": {
+    "gsap": "^3.13.0",
     "vue": "^3.5.13",
     "vue-router": "^4.5.0"
   },

--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -1,7 +1,15 @@
 <script setup lang="ts">
+import { onMounted, getCurrentInstance } from 'vue'
+
 defineProps<{
   msg: string
 }>()
+
+const { $gsap } = getCurrentInstance()!.appContext.config.globalProperties
+
+onMounted(() => {
+  $gsap.from('.greetings h1', { opacity: 0, y: -20 })
+})
 </script>
 
 <template>

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,9 +3,11 @@ import './assets/main.css'
 import { createApp } from 'vue'
 import App from './App.vue'
 import router from './router'
+import GsapPlugin from './plugins/gsap'
 
 const app = createApp(App)
 
 app.use(router)
+app.use(GsapPlugin)
 
 app.mount('#app')

--- a/src/plugins/gsap.ts
+++ b/src/plugins/gsap.ts
@@ -1,0 +1,8 @@
+import { App } from 'vue'
+import { gsap } from 'gsap'
+
+export default {
+  install(app: App) {
+    app.config.globalProperties.$gsap = gsap
+  },
+}


### PR DESCRIPTION
## Summary
- install GSAP
- expose GSAP via a Vue plugin
- register the plugin in main.ts
- animate HelloWorld header as an example
- document how to use GSAP

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68405deac250832ba87a660b0b102b03